### PR TITLE
feat: update NoSQL models for Activities and Update

### DIFF
--- a/src/main/java/com/uade/backendgestionbd2/model/Activities.java
+++ b/src/main/java/com/uade/backendgestionbd2/model/Activities.java
@@ -7,8 +7,8 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import java.util.HashSet;
 import java.util.Set;
 
-@Document(collection = "progress")
-public class Progress {
+@Document(collection = "activities")
+public class Activities {
 
     @Id
     private String progress_id;
@@ -16,12 +16,12 @@ public class Progress {
     private String task_id;
 
     @DBRef
-    private Set<Update> updates = new HashSet<>();
+    private Set<String> updates_ids = new HashSet<>();
 
-    public Progress() {
+    public Activities() {
     }
 
-    public Progress(String task_id) {
+    public Activities(String task_id) {
         this.task_id = task_id;
     }
 

--- a/src/main/java/com/uade/backendgestionbd2/model/Update.java
+++ b/src/main/java/com/uade/backendgestionbd2/model/Update.java
@@ -19,7 +19,7 @@ public class Update {
     private String update_id;
 
     @DBRef
-    private Progress progress;
+    private Activities activities;
 
     private String user_id;
     private String description;
@@ -30,8 +30,8 @@ public class Update {
     public Update() {
     }
 
-    public Update(Progress progress, String user_id, String description, Date timestamp, int progress_percentage, int time_worked) {
-        this.progress = progress;
+    public Update(Activities activities, String user_id, String description, Date timestamp, int progress_percentage, int time_worked) {
+        this.activities = activities;
         this.user_id = user_id;
         this.description = description;
         this.timestamp = timestamp;


### PR DESCRIPTION
- Changed 'progress_id' to 'activiti_id' in Activities model.
- Modified Activities model to store only IDs of Update documents instead of references.
- Ensured integrity and relationships by storing update IDs in a Set<String> in Activities model.
- Updated JSON documentation for the new structure.